### PR TITLE
Python dependencies, dos2unix, various R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,23 @@ RUN echo "umask 002" >> /etc/bash.bashrc
 
 
 # install system level dependencies
-apt-get update && apt-get install -y --no-install-recommends \
-    dos2unix
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dos2unix \
+    libpython3-dev \
+    python3-dev \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
 
+
+# install pip dependencies
+RUN python3 -m pip --no-cache-dir install --upgrade \
+  pip \
+  setuptools
+# install public python dependencies
+RUN python3 -m pip --no-cache-dir install --upgrade \
+  pymc3 \
+  PyPDF2 \
+  rpy2
 
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ FROM rocker/geospatial:3.6.3
 RUN echo "umask 002" >> /etc/bash.bashrc
 
 
+# install system level dependencies
+apt-get update && apt-get install -y --no-install-recommends \
+    dos2unix
+
+
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \
     argparse \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ apt-get update && apt-get install -y --no-install-recommends \
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \
     argparse \
+    arrow \
     config \
     devtools \
+    fs \
     pkgdown \
     remotes \
     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds

--- a/installed_versions/R_packages.csv
+++ b/installed_versions/R_packages.csv
@@ -1,6 +1,7 @@
 Package,Version
 abind,1.4-5
 argparse,2.0.1
+arrow,0.17.0
 askpass,1.1
 assertable,0.2.7
 assertive,0.3-5
@@ -243,6 +244,7 @@ remotes,2.1.1
 reprex,0.3.0
 reshape,0.8.8
 reshape2,1.4.4
+reticulate,1.15
 rex,1.2.0
 rgdal,1.4-8
 rgeos,0.5-2

--- a/installed_versions/apt_packages.txt
+++ b/installed_versions/apt_packages.txt
@@ -1,271 +1,283 @@
 Listing...
-bash-completion/stable,now 1:2.8-6 all [installed]
+bash-completion/now 1:2.8-6 all [installed,local]
   programmable completion for the bash shell
 
-ca-certificates/stable,now 20190110 all [installed]
+ca-certificates/now 20190110 all [installed,local]
   Common CA certificates
 
-curl/stable,stable,now 7.64.0-4+deb10u1 amd64 [installed]
+curl/now 7.64.0-4+deb10u1 amd64 [installed,local]
   command line tool for transferring data with URL syntax
 
-default-jdk/stable,now 2:1.11-71 amd64 [installed]
+default-jdk/now 2:1.11-71 amd64 [installed,local]
   Standard Java or Java compatible Development Kit
 
-file/stable,stable,now 1:5.35-4+deb10u1 amd64 [installed]
+dos2unix/now 7.4.0-1 amd64 [installed,local]
+  convert text file line endings between CRLF and LF
+
+file/now 1:5.35-4+deb10u1 amd64 [installed,local]
   Recognize the type of data in a file using "magic" numbers
 
-fonts-roboto/stable,now 2:0~20170802-3 all [installed]
+fonts-roboto/now 2:0~20170802-3 all [installed,local]
   metapackage to pull in Roboto fonts
 
-fonts-texgyre/stable,now 20180621-3 all [installed]
+fonts-texgyre/now 20180621-3 all [installed,local]
   OpenType fonts based on URW Fonts
 
-g++/stable,now 4:8.3.0-1 amd64 [installed]
+g++/now 4:8.3.0-1 amd64 [installed,local]
   GNU C++ compiler
 
-gfortran/stable,now 4:8.3.0-1 amd64 [installed]
+gfortran/now 4:8.3.0-1 amd64 [installed,local]
   GNU Fortran 95 compiler
 
-ghostscript/stable,stable,now 9.27~dfsg-2+deb10u3 amd64 [installed]
+ghostscript/now 9.27~dfsg-2+deb10u3 amd64 [installed,local]
   interpreter for the PostScript language and for PDF
 
-git/stable,stable,now 1:2.20.1-2+deb10u3 amd64 [installed]
+git/now 1:2.20.1-2+deb10u3 amd64 [installed,local]
   fast, scalable, distributed revision control system
 
-gsfonts/stable,now 1:8.11+urwcyr1.0.7~pre44-4.4 all [installed]
+gsfonts/now 1:8.11+urwcyr1.0.7~pre44-4.4 all [installed,local]
   Fonts for the Ghostscript interpreter(s)
 
-iproute2/stable,now 4.20.0-2 amd64 [installed]
+iproute2/now 4.20.0-2 amd64 [installed,local]
   networking and traffic control tools
 
-iputils-ping/stable,now 3:20180629-2+deb10u1 amd64 [installed]
+iputils-ping/now 3:20180629-2+deb10u1 amd64 [installed,local]
   Tools to test the reachability of network hosts
 
-lbzip2/stable,now 2.5-2 amd64 [installed]
+lbzip2/now 2.5-2 amd64 [installed,local]
   fast, multi-threaded bzip2 utility
 
-less/stable,now 487-0.1+b1 amd64 [installed]
+less/now 487-0.1+b1 amd64 [installed,local]
   pager program similar to more
 
-libapparmor1/stable,now 2.13.2-10 amd64 [installed]
+libapparmor1/now 2.13.2-10 amd64 [installed,local]
   changehat AppArmor library
 
-libblas-dev/stable,now 3.8.0-2 amd64 [installed]
+libblas-dev/now 3.8.0-2 amd64 [installed,local]
   Basic Linear Algebra Subroutines 3, static library
 
-libbz2-1.0/stable,now 1.0.6-9.2~deb10u1 amd64 [installed]
+libbz2-1.0/now 1.0.6-9.2~deb10u1 amd64 [installed,local]
   high-quality block-sorting file compressor library - runtime
 
-libbz2-dev/stable,now 1.0.6-9.2~deb10u1 amd64 [installed]
+libbz2-dev/now 1.0.6-9.2~deb10u1 amd64 [installed,local]
   high-quality block-sorting file compressor library - development
 
-libcairo2-dev/stable,now 1.16.0-4 amd64 [installed]
+libcairo2-dev/now 1.16.0-4 amd64 [installed,local]
   Development files for the Cairo 2D graphics library
 
-libclang-dev/stable,now 1:7.0-47 amd64 [installed]
+libclang-dev/now 1:7.0-47 amd64 [installed,local]
   clang library - Development package
 
-libcurl4/stable,stable,now 7.64.0-4+deb10u1 amd64 [installed]
+libcurl4/now 7.64.0-4+deb10u1 amd64 [installed,local]
   easy-to-use client-side URL transfer library (OpenSSL flavour)
 
-libedit2/stable,now 3.1-20181209-1 amd64 [installed]
+libedit2/now 3.1-20181209-1 amd64 [installed,local]
   BSD editline and history libraries
 
-libfftw3-dev/stable,now 3.3.8-2 amd64 [installed]
+libfftw3-dev/now 3.3.8-2 amd64 [installed,local]
   Library for computing Fast Fourier Transforms - development
 
-libgdal-dev/stable,now 2.4.0+dfsg-1+b1 amd64 [installed]
+libgdal-dev/now 2.4.0+dfsg-1+b1 amd64 [installed,local]
   Geospatial Data Abstraction Library - Development files
 
-libgeos-dev/stable,now 3.7.1-1 amd64 [installed]
+libgeos-dev/now 3.7.1-1 amd64 [installed,local]
   Geometry engine for GIS - Development files
 
-libgl1-mesa-dev/stable,now 18.3.6-2+deb10u1 amd64 [installed]
+libgl1-mesa-dev/now 18.3.6-2+deb10u1 amd64 [installed,local]
   free implementation of the OpenGL API -- GLX development files
 
-libglu1-mesa-dev/stable,now 9.0.0-2.1+b3 amd64 [installed]
+libglu1-mesa-dev/now 9.0.0-2.1+b3 amd64 [installed,local]
   Mesa OpenGL utility library -- development files
 
-libgsl-dev/stable,now 2.5+dfsg-6 amd64 [installed]
+libgsl-dev/now 2.5+dfsg-6 amd64 [installed,local]
   GNU Scientific Library (GSL) -- development package
 
-libhdf4-alt-dev/stable,now 4.2.13-4 amd64 [installed]
+libhdf4-alt-dev/now 4.2.13-4 amd64 [installed,local]
   Hierarchical Data Format development files (without NetCDF)
 
-libhdf5-dev/stable,now 1.10.4+repack-10 amd64 [installed]
+libhdf5-dev/now 1.10.4+repack-10 amd64 [installed,local]
   Hierarchical Data Format 5 (HDF5) - development files - serial version
 
-libhunspell-dev/stable,now 1.7.0-2 amd64 [installed]
+libhunspell-dev/now 1.7.0-2 amd64 [installed,local]
   spell checker and morphological analyzer (development)
 
-libicu-dev/stable,stable,now 63.1-6+deb10u1 amd64 [installed]
+libicu-dev/now 63.1-6+deb10u1 amd64 [installed,local]
   Development files for International Components for Unicode
 
-libicu63/stable,stable,now 63.1-6+deb10u1 amd64 [installed]
+libicu63/now 63.1-6+deb10u1 amd64 [installed,local]
   International Components for Unicode
 
-libjpeg-dev/stable,now 1:1.5.2-2 all [installed]
+libjpeg-dev/now 1:1.5.2-2 all [installed,local]
   Development files for the JPEG library [dummy package]
 
-libjpeg62-turbo/stable,now 1:1.5.2-2+b1 amd64 [installed]
+libjpeg62-turbo/now 1:1.5.2-2+b1 amd64 [installed,local]
   libjpeg-turbo JPEG runtime library
 
-libjq-dev/stable,now 1.5+dfsg-2+b1 amd64 [installed]
+libjq-dev/now 1.5+dfsg-2+b1 amd64 [installed,local]
   lightweight and flexible command-line JSON processor - development files
 
-liblwgeom-dev/stable,now 2.5.1+dfsg-1 amd64 [installed]
+liblwgeom-dev/now 2.5.1+dfsg-1 amd64 [installed,local]
   PostGIS "Lightweight Geometry" library - Development files
 
-liblzma-dev/stable,now 5.2.4-1 amd64 [installed]
+liblzma-dev/now 5.2.4-1 amd64 [installed,local]
   XZ-format compression library - development files
 
-liblzma5/stable,now 5.2.4-1 amd64 [installed]
+liblzma5/now 5.2.4-1 amd64 [installed,local]
   XZ-format compression library
 
-libmagick++-dev/stable,now 8:6.9.10.23+dfsg-2.1 all [installed]
+libmagick++-dev/now 8:6.9.10.23+dfsg-2.1 all [installed,local]
   object-oriented C++ interface to ImageMagick -- dummy package
 
-libmariadbclient-dev/stable,now 1:10.3.22-0+deb10u1 amd64 [installed]
+libmariadbclient-dev/now 1:10.3.22-0+deb10u1 amd64 [installed,local]
   MariaDB database development files (transitional package)
 
-libmariadbd-dev/stable,now 1:10.3.22-0+deb10u1 amd64 [installed]
+libmariadbd-dev/now 1:10.3.22-0+deb10u1 amd64 [installed,local]
   MariaDB embedded database, development files
 
-libnetcdf-dev/stable,now 1:4.6.2-1 amd64 [installed]
+libnetcdf-dev/now 1:4.6.2-1 amd64 [installed,local]
   creation, access, and sharing of scientific data
 
-libnode-dev/stable,stable,now 10.19.0~dfsg1-1 amd64 [installed]
+libnode-dev/now 10.19.0~dfsg1-1 amd64 [installed,local]
   evented I/O for V8 javascript (development files)
 
-libopenblas-dev/stable,now 0.3.5+ds-3 amd64 [installed]
+libopenblas-dev/now 0.3.5+ds-3 amd64 [installed,local]
   Optimized BLAS (linear algebra) library (development files)
 
-libopenmpi-dev/stable,now 3.1.3-11 amd64 [installed]
+libopenmpi-dev/now 3.1.3-11 amd64 [installed,local]
   high performance message passing library -- header files
 
-libpangocairo-1.0-0/stable,now 1.42.4-8~deb10u1 amd64 [installed]
+libpangocairo-1.0-0/now 1.42.4-8~deb10u1 amd64 [installed,local]
   Layout and rendering of internationalized text
 
-libpcre3/stable,now 2:8.39-12 amd64 [installed]
+libpcre3/now 2:8.39-12 amd64 [installed,local]
   Old Perl 5 Compatible Regular Expression Library - runtime files
 
-libpng16-16/stable,now 1.6.36-6 amd64 [installed]
+libpng16-16/now 1.6.36-6 amd64 [installed,local]
   PNG library - runtime (version 1.6)
 
-libpq-dev/stable,stable,now 11.7-0+deb10u1 amd64 [installed]
+libpq-dev/now 11.7-0+deb10u1 amd64 [installed,local]
   header files for libpq5 (PostgreSQL library)
 
-libproj-dev/stable,now 5.2.0-1 amd64 [installed]
+libproj-dev/now 5.2.0-1 amd64 [installed,local]
   Cartographic projection library (development files)
 
-libprotobuf-dev/stable,now 3.6.1.3-2 amd64 [installed]
+libprotobuf-dev/now 3.6.1.3-2 amd64 [installed,local]
   protocol buffers C++ library (development files) and proto files
 
-librdf0-dev/stable,now 1.0.17-1.1+b1 amd64 [installed]
+libpython3-dev/now 3.7.3-1 amd64 [installed,local]
+  header files and a static library for Python (default)
+
+librdf0-dev/now 1.0.17-1.1+b1 amd64 [installed,local]
   Redland RDF library development libraries and headers
 
-libreadline7/stable,now 7.0-5 amd64 [installed]
+libreadline7/now 7.0-5 amd64 [installed,local]
   GNU readline and history libraries, run-time libraries
 
-libsasl2-dev/stable,stable,now 2.1.27+dfsg-1+deb10u1 amd64 [installed]
+libsasl2-dev/now 2.1.27+dfsg-1+deb10u1 amd64 [installed,local]
   Cyrus SASL - development files for authentication abstraction library
 
-libsqlite0-dev/stable,now 2.8.17-15 amd64 [installed]
+libsqlite0-dev/now 2.8.17-15 amd64 [installed,local]
   SQLite 2 development files
 
-libsqlite3-dev/stable,now 3.27.2-3 amd64 [installed]
+libsqlite3-dev/now 3.27.2-3 amd64 [installed,local]
   SQLite 3 development files
 
-libssh2-1-dev/stable,now 1.8.0-2.1 amd64 [installed]
+libssh2-1-dev/now 1.8.0-2.1 amd64 [installed,local]
   SSH2 client-side library (development headers)
 
-libssl-dev/stable,stable,now 1.1.1d-0+deb10u3 amd64 [installed]
+libssl-dev/now 1.1.1d-0+deb10u3 amd64 [installed,local]
   Secure Sockets Layer toolkit - development files
 
-libtiff-dev/stable,stable,now 4.1.0+git191117-2~deb10u1 amd64 [installed]
+libtiff-dev/now 4.1.0+git191117-2~deb10u1 amd64 [installed,local]
   Tag Image File Format library (TIFF), development files
 
-libtiff5/stable,stable,now 4.1.0+git191117-2~deb10u1 amd64 [installed]
+libtiff5/now 4.1.0+git191117-2~deb10u1 amd64 [installed,local]
   Tag Image File Format (TIFF) library
 
-libudunits2-dev/stable,now 2.2.26-5 amd64 [installed]
+libudunits2-dev/now 2.2.26-5 amd64 [installed,local]
   Development files for the libunits physical units package
 
-libxml2-dev/stable,now 2.9.4+dfsg1-7+b3 amd64 [installed]
+libxml2-dev/now 2.9.4+dfsg1-7+b3 amd64 [installed,local]
   Development files for the GNOME XML library
 
-libzmq3-dev/stable,stable,now 4.3.1-4+deb10u1 amd64 [installed]
+libzmq3-dev/now 4.3.1-4+deb10u1 amd64 [installed,local]
   lightweight messaging kernel (development files)
 
-locales/stable,now 2.28-10 all [installed]
+locales/now 2.28-10 all [installed,local]
   GNU C Library: National Language (locale) data [support]
 
-lsb-release/stable,now 10.2019051400 all [installed]
+lsb-release/now 10.2019051400 all [installed,local]
   Linux Standard Base version reporting utility
 
-make/stable,now 4.2.1-1.2 amd64 [installed]
+make/now 4.2.1-1.2 amd64 [installed,local]
   utility for directing compilation
 
-multiarch-support/stable,now 2.28-10 amd64 [installed]
+multiarch-support/now 2.28-10 amd64 [installed,local]
   Transitional package to ensure multiarch compatibility
 
-netcdf-bin/stable,now 1:4.6.2-1 amd64 [installed]
+netcdf-bin/now 1:4.6.2-1 amd64 [installed,local]
   Programs for reading and writing NetCDF files
 
-postgis/stable,now 2.5.1+dfsg-1 amd64 [installed]
+postgis/now 2.5.1+dfsg-1 amd64 [installed,local]
   Geographic objects support for PostgreSQL
 
-procps/stable,now 2:3.3.15-2 amd64 [installed]
+procps/now 2:3.3.15-2 amd64 [installed,local]
   /proc file system utilities
 
-protobuf-compiler/stable,now 3.6.1.3-2 amd64 [installed]
+protobuf-compiler/now 3.6.1.3-2 amd64 [installed,local]
   compiler for protocol buffer definition files
 
-psmisc/stable,now 23.2-1 amd64 [installed]
+psmisc/now 23.2-1 amd64 [installed,local]
   utilities that use the proc file system
 
-python-setuptools/stable,now 40.8.0-1 all [installed]
+python-setuptools/now 40.8.0-1 all [installed,local]
   Python Distutils Enhancements
 
-qpdf/stable,now 8.4.0-2 amd64 [installed]
+python3-dev/now 3.7.3-1 amd64 [installed,local]
+  header files and a static library for Python (default)
+
+python3-pip/now 18.1-5 all [installed,local]
+  Python package installer
+
+qpdf/now 8.4.0-2 amd64 [installed,local]
   tools for transforming and inspecting PDF files
 
 rstudio-server/now 1.2.5042 amd64 [installed,local]
   RStudio Server
 
-sqlite3/stable,now 3.27.2-3 amd64 [installed]
+sqlite3/now 3.27.2-3 amd64 [installed,local]
   Command line interface for SQLite 3
 
-ssh/stable,now 1:7.9p1-10+deb10u2 all [installed]
+ssh/now 1:7.9p1-10+deb10u2 all [installed,local]
   secure shell client and server (metapackage)
 
-sudo/stable,now 1.8.27-1+deb10u2 amd64 [installed]
+sudo/now 1.8.27-1+deb10u2 amd64 [installed,local]
   Provide limited super user privileges to specific users
 
-texinfo/stable,now 6.5.0.dfsg.1-4+b1 amd64 [installed]
+texinfo/now 6.5.0.dfsg.1-4+b1 amd64 [installed,local]
   Documentation system for on-line information and printed output
 
 texlive-local/now 2016-1~9 all [installed,local]
   A local installation of TeX Live 2016.
 
-tk-dev/stable,now 8.6.9+1 amd64 [installed]
+tk-dev/now 8.6.9+1 amd64 [installed,local]
   Toolkit for Tcl and X11 (default version) - development files
 
-unixodbc-dev/stable,now 2.3.6-0.1 amd64 [installed]
+unixodbc-dev/now 2.3.6-0.1 amd64 [installed,local]
   ODBC libraries for UNIX (development files)
 
-unzip/stable,now 6.0-23+deb10u1 amd64 [installed]
+unzip/now 6.0-23+deb10u1 amd64 [installed,local]
   De-archiver for .zip files
 
-vim/stable,now 2:8.1.0875-5 amd64 [installed]
+vim/now 2:8.1.0875-5 amd64 [installed,local]
   Vi IMproved - enhanced vi editor
 
-wget/stable,now 1.20.1-1.1 amd64 [installed]
+wget/now 1.20.1-1.1 amd64 [installed,local]
   retrieves files from the web
 
-zip/stable,now 3.0-11+b1 amd64 [installed]
+zip/now 3.0-11+b1 amd64 [installed,local]
   Archiver for .zip files
 
-zlib1g/stable,now 1:1.2.11.dfsg-1 amd64 [installed]
+zlib1g/now 1:1.2.11.dfsg-1 amd64 [installed,local]
   compression library - runtime
 


### PR DESCRIPTION
## Describe changes

This PR resolves three issues
* installs two R packages that were listed to be added `arrow` and `fs`. Fixes #10. 
* adds `dos2unix` to resolve warnings in some of our internal upload functions.  Fixes #23.
* uses pip to install basic python dependencies. Fixes #11.

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [ ] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [ ] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [ ] Did you test your work? Either via automated tests or documented manual testing?

## Details of PR

Once we start using R4.0> as the base image we can use the rocker helper scripts to install python https://github.com/rocker-org/rocker-versioned2/blob/master/scripts/install_python.sh. And then would just need the pip install commands in our dockerfile.
