### PR TITLE
Change default python to python3 #29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 
+# change default python to python3
+RUN echo "alias python=python3" >> /etc/bash.bashrc
+
 # install pip dependencies
 RUN python3 -m pip --no-cache-dir install --upgrade \
   pip \
@@ -22,6 +25,7 @@ RUN python3 -m pip --no-cache-dir install --upgrade \
   pymc3 \
   PyPDF2 \
   rpy2
+
 
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \


### PR DESCRIPTION
## Describe changes

Changing the default python to python3 since our pipeline using python3 by default and the internal shell scripts call `python` and aren't flexible

## What issues are related

Fixes #29

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [ ] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [ ] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [X] Did you test your work? Either via automated tests or documented manual testing?
