### PR TITLE
have Rstudio server use the default umask setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM rocker/geospatial:3.6.3
 
 # set default umask
 RUN echo "umask 002" >> /etc/bash.bashrc
+# have Rstudio server use the default umask https://docs.rstudio.com/ide/server-pro/access-and-security.html#umask
+RUN echo "server-set-umask=0" >> /etc/rstudio/rserver.conf
 
 
 # install system level dependencies


### PR DESCRIPTION
## Describe changes

Rstudio server defaults to umask 022 on startup. We want it to use the system level default umask which this change does .

https://docs.rstudio.com/ide/server-pro/access-and-security.html#umask

## What issues are related

Related to https://github.com/ihmeuw-demographics/model_template/issues/35

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [ ] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [ ] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [ ] Did you test your work? Either via automated tests or documented manual testing?
