### PR TITLE
fix rpy2 import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN python3 -m pip --no-cache-dir install --upgrade \
   pymc3 \
   PyPDF2 \
   rpy2
-
+# fix rpy2 per solution here https://github.com/darribas/gds_env/issues/2 with path to `libR.so`
+ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib/:${LD_LIBRARY_PATH}
 
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \


### PR DESCRIPTION
## Describe changes

Fixes issue with importing `rpy2.robjects`.

https://stackoverflow.com/questions/54053492/rpy2-version-built-against-one-r-version-but-running-linked-to-another
https://github.com/darribas/gds_env/issues/2

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [ ] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [ ] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [x] Did you test your work? Either via automated tests or documented manual testing?

## Details of PR

Example of error when importing `rpy2.robjects`
```
$ docker run -it registry-app-p01.ihme.washington.edu/demographics/internal:v2020.0.7 /bin/bash
root@24540f005192:/# python3
Python 3.7.3 (default, Jul 25 2020, 13:03:44)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import rpy2.robjects as robjects
Error: package or namespace load failed for ‘methods’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/usr/local/lib/R/library/methods/libs/methods.so':
  libR.so: cannot open shared object file: No such file or directory
Warning message:
package "methods" in options("defaultPackages") was not found
Error: package or namespace load failed for ‘utils’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/usr/local/lib/R/library/utils/libs/utils.so':
  libR.so: cannot open shared object file: No such file or directory
Error: package or namespace load failed for ‘grDevices’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/usr/local/lib/R/library/grDevices/libs/grDevices.so':
  libR.so: cannot open shared object file: No such file or directory
Error: package or namespace load failed for ‘graphics’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/usr/local/lib/R/library/grDevices/libs/grDevices.so':
  libR.so: cannot open shared object file: No such file or directory
Error: package or namespace load failed for ‘stats’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/usr/local/lib/R/library/grDevices/libs/grDevices.so':
  libR.so: cannot open shared object file: No such file or directory
Error: package or namespace load failed for ‘methods’ in dyn.load(file, DLLpath = DLLpath, ...):
 unable to load shared object '/usr/local/lib/R/library/methods/libs/methods.so':
  libR.so: cannot open shared object file: No such file or directory
During startup - Warning messages:
1: package ‘utils’ in options("defaultPackages") was not found
2: package ‘grDevices’ in options("defaultPackages") was not found
3: package ‘graphics’ in options("defaultPackages") was not found
4: package ‘stats’ in options("defaultPackages") was not found
5: package ‘methods’ in options("defaultPackages") was not found
R[write to console]: Error in dyn.load(file, DLLpath = DLLpath, ...) :
  unable to load shared object '/usr/local/lib/R/library/methods/libs/methods.so':
  libR.so: cannot open shared object file: No such file or directory

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/dist-packages/rpy2/robjects/__init__.py", line 19, in <module>
    from rpy2.robjects.robject import RObjectMixin, RObject
  File "/usr/local/lib/python3.7/dist-packages/rpy2/robjects/robject.py", line 58, in <module>
    class RObjectMixin(object):
  File "/usr/local/lib/python3.7/dist-packages/rpy2/robjects/robject.py", line 70, in RObjectMixin
    __show = _get_exported_value('methods', 'show')
  File "/usr/local/lib/python3.7/dist-packages/rpy2/rinterface_lib/conversion.py", line 44, in _
    cdata = function(*args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/rpy2/rinterface.py", line 624, in __call__
    raise embedded.RRuntimeError(_rinterface._geterrmessage())
rpy2.rinterface_lib.embedded.RRuntimeError: Error in dyn.load(file, DLLpath = DLLpath, ...) :
  unable to load shared object '/usr/local/lib/R/library/methods/libs/methods.so':
  libR.so: cannot open shared object file: No such file or directory
```