### PR TITLE
switch to development version of arrow temporarily

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN python3 -m pip --no-cache-dir install --upgrade \
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \
     argparse \
-    arrow \
+    # arrow \
     config \
     devtools \
     fs \
@@ -41,6 +41,8 @@ RUN install2.r --error --deps TRUE \
     pacman \
     pkgdown \
     remotes \
+    # install temporary development version until cran version is updated https://arrow.apache.org/docs/r/index.html
+    && R -e 'install.packages("arrow", repos = "https://dl.bintray.com/ursalabs/arrow-r"); library(arrow)' \
     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 


### PR DESCRIPTION
## Describe changes

The cran version of arrow has not yet been updated to include the `write_dataset` function. So install from the nightly build location as described here https://arrow.apache.org/docs/r/index.html.

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [ ] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [ ] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [ ] Did you test your work? Either via automated tests or documented manual testing?