### PR TITLE
use .Rprofile to fix rstudio umask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM rocker/geospatial:3.6.3
 
 # set default umask
 RUN echo "umask 002" >> /etc/bash.bashrc
-# have Rstudio server use the default umask https://docs.rstudio.com/ide/server-pro/access-and-security.html#umask
-RUN echo "server-set-umask=0" >> /etc/rstudio/rserver.conf
+# use version specific `Rprofile.site` to fix Rstudio umask
+RUN echo "Sys.umask(2)" >> /usr/local/lib/R/etc/Rprofile.site
 
 
 # install system level dependencies


### PR DESCRIPTION
## Describe changes

Rstudio was not using the umask set in the default bashrc. So using the R version specific `.Rprofile` to specify the default umask, this is run everytime a new R session is started. 

The previous solution that was tried does not seem to work https://docs.rstudio.com/ide/server-pro/access-and-security.html#umask

## What issues are related

Related to https://github.com/ihmeuw-demographics/model_template/issues/35

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [ ] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [X] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [X] Did you test your work? Either via automated tests or documented manual testing?

## Details of PR

Tested with a local build of the container, opened up an Rstudio session and confirmed `Sys.umask()` returns `2`.

```
docker build -t ihmeuwdemographics/base:test .
docker run -e PASSWORD=test --rm -p 8787:8787 ihmeuwdemographics/base:test
```
