### PR TITLE
Switch back to cran version of arrow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib/:${LD_LIBRARY_PATH}
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \
     argparse \
-    # arrow \
+    arrow \
     config \
     devtools \
     fs \
@@ -44,8 +44,6 @@ RUN install2.r --error --deps TRUE \
     readstata13 \
     remotes \
     rjson \
-    # install temporary development version until cran version is updated https://arrow.apache.org/docs/r/index.html
-    && R -e 'install.packages("arrow", repos = "https://dl.bintray.com/ursalabs/arrow-r"); library(arrow)' \
     && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 


### PR DESCRIPTION
## Describe changes

The cran version of arrow was recently updated to include new functions that we were previously accessing via a development version of arrow.

So this PR switches back to the cran version.