### PR TITLE
update cran repo to use when installing R packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,14 @@ RUN python3 -m pip --no-cache-dir install --upgrade \
 # fix rpy2 per solution here https://github.com/darribas/gds_env/issues/2 with path to `libR.so`
 ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib/:${LD_LIBRARY_PATH}
 
+# update mran snapshot mirror to use when installing R packages
+# see 'Versioned' section here https://journal.r-project.org/archive/2017/RJ-2017-065/RJ-2017-065.pdf
+# and Dockerfile from rocker builds https://hub.docker.com/r/rocker/r-ver/dockerfile
+RUN BASE_BUILD_DATE=$(date +"%Y-%m-%d") \
+  && MRAN=https://mran.microsoft.com/snapshot/${BASE_BUILD_DATE} \
+  && echo MRAN=$MRAN >> /etc/environment \
+  && echo "options(repos = c(CRAN='$MRAN'), download.file.method = 'libcurl')" >> /usr/local/lib/R/etc/Rprofile.site
+
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \
     argparse \
@@ -44,10 +52,7 @@ RUN install2.r --error --deps TRUE \
     readstata13 \
     remotes \
     rjson \
-    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
-    # this theoretically isn't needed but c++ dependencies are not getting installed above
-    # https://arrow.apache.org/docs/r/articles/install.html#troubleshooting-and-additional-options-1
-    && R -e "arrow::install_arrow()"
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 
 # install tmb related packages


### PR DESCRIPTION
## Describe changes

The rocker images are set up to use a cran mirror from the day the image was built. See the "Versioned" section on page 530 here for more info https://journal.r-project.org/archive/2017/RJ-2017-065/RJ-2017-065.pdf.

We are still building from [rocker/geospatial:3.6.3](https://hub.docker.com/layers/rocker/geospatial/3.6.3/images/sha256-1067dddabd8b6b238ed8ddf87ef6e8cd69406d80602356ea39b3ecba31497da5?context=explore) which was built 6 months ago so all installed R packages were being installed with the version available on cran at that time. This also means other packages already installed on the image are from 6 months ago. 

We are waiting to upgrade to more recent rocker versions due to this issue https://github.com/ihmeuw-demographics/docker-base/issues/26.

This change, updates the default cran url to the date we are building our image on. This is needed because we want to install newer versions of specific packages like `arrow`.

## What issues are related

Related to https://github.com/ihmeuw-demographics/docker-base/pull/41.
Related to https://github.com/ihmeuw-demographics/docker-base/pull/39

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [X] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [X] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [X] Did you test your work? Either via automated tests or documented manual testing?

## Details of PR

Tested the build locally to confirm 2.0.0 was being installed correctly along with the C++ dependencies. Then tried basic arrow commands to confirm it is working.

```
library(arrow)
arrow::set_cpu_count(5)
```
