### PR TITLE
Update base image and fix arrow install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN python3 -m pip --no-cache-dir install --upgrade \
 # fix rpy2 per solution here https://github.com/darribas/gds_env/issues/2 with path to `libR.so`
 ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib/:${LD_LIBRARY_PATH}
 
+
 # install other packages (alphanumeric order)
 RUN install2.r --error --deps TRUE \
     argparse \
@@ -44,10 +45,7 @@ RUN install2.r --error --deps TRUE \
     readstata13 \
     remotes \
     rjson \
-    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
-    # this theoretically isn't needed but c++ dependencies are not getting installed above
-    # https://arrow.apache.org/docs/r/articles/install.html#troubleshooting-and-additional-options-1
-    && R -e "arrow::install_arrow()"
+    && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 
 # install tmb related packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:3.6.3
+FROM rocker/geospatial:4.0.3
 
 # set default umask
 RUN echo "umask 002" >> /etc/bash.bashrc


### PR DESCRIPTION
## Describe changes

There is now a workaround to the issue that was previously preventing compatibility between these newer rstudio versions and singularity. No changes are needed in the actual docker image, only the singularity shell scripts in `docker-internal`.

This PR updates to the current latest rocker image.

Also this should fix an issue with the arrow version installed. The rocker images are set up to use a cran mirror from the day the image was built. See the "Versioned" section on page 530 here for more info https://journal.r-project.org/archive/2017/RJ-2017-065/RJ-2017-065.pdf. The previous tag rocker/geospatial:3.6.3 was built 6 months ago so all installed R packages were being installed with the version available on cran at that time. This also meant other packages already installed on the image were from 6 months ago.

Also this speeds up our builds from over an hour to 15 minutes.

## What issues are related

Fixes #26 

## Checklist

<!-- You can erase any parts of this checklist that are not applicable to your PR. -->

### Other Repositories

* [X] Did you update any relevant documentation (`README.md`, script headers, wiki pages, internal IHME hub pages etc.)?
* [X] Could someone else on the `ihmeuw-demographics` team replicate or use your work using available documentation?
* [X] Did you test your work? Either via automated tests or documented manual testing?